### PR TITLE
Update 01_higher_order_functions.js

### DIFF
--- a/01_higher_order_functions/01_higher_order_functions.js
+++ b/01_higher_order_functions/01_higher_order_functions.js
@@ -38,4 +38,4 @@ const reduce = (reducer, initial, arr) => {
 
 const filter = (reducer, arr) => reduce(reducer, [], arr)
 const shortestReducer = (prev, next) => prev.duration < next.duration ? prev : next
-const shortest = songs.reduce(shortestReducer, songs) /*?*/
+const shortest = songs.reduce(shortestReducer)/*?*/


### PR DESCRIPTION
fix: the second parameter in Array.reduce should be skipped